### PR TITLE
Add check for cancellation token on async methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Prevents calling `Queryable` methods that synchronously execute the query such a
 
 To fix this warning, use the asynchronous version of the method such as `SingleAsync()` or `FirstOrDefaultAsync()`.
 
+3. Async methods must have CancellationToken parameter analyzer
+
+Ensures that methods ending with "Async" in non-Controller classes have a CancellationToken parameter. This enforces the best practice of supporting cancellation in all asynchronous operations.
+
+To fix this warning, add a CancellationToken parameter to the method signature. The parameter can be optional with a default value of `default`.
+
 ## Credits
 
 Glory to Jehovah, Lord of Lords and King of Kings, creator of Heaven and Earth, who through his Son Jesus Christ,

--- a/src/Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Analyzers/AnalyzerReleases.Shipped.md
@@ -9,3 +9,4 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
 SHANE001 | Usage | Warning | DoNotCastIQueryableImplicitlyAnalyzer
 SHANE002 | Usage | Warning | DoNotCallQueryableSynchronousMethodsAnalyzer
+SHANE003 | Usage | Warning | AsyncMethodsMustHaveCancellationTokenAnalyzer

--- a/src/Analyzers/AsyncMethodsMustHaveCancellationTokenAnalyzer.cs
+++ b/src/Analyzers/AsyncMethodsMustHaveCancellationTokenAnalyzer.cs
@@ -1,0 +1,75 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Shane32.Analyzers.Helpers;
+
+namespace Shane32.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class AsyncMethodsMustHaveCancellationTokenAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor AsyncMethodsMustHaveCancellationToken = new(
+        id: DiagnosticIds.ASYNC_METHODS_MUST_HAVE_CANCELLATION_TOKEN,
+        title: "Async methods should have a CancellationToken parameter",
+        messageFormat: "Method '{0}' ends with 'Async' but does not have a CancellationToken parameter",
+        category: DiagnosticCategories.USAGE,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
+        AsyncMethodsMustHaveCancellationToken);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterSyntaxNodeAction(AnalyzeMethodDeclaration, SyntaxKind.MethodDeclaration);
+    }
+
+    private void AnalyzeMethodDeclaration(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not MethodDeclarationSyntax methodDeclaration)
+            return;
+
+        // Check if method name ends with "Async"
+        var methodName = methodDeclaration.Identifier.Text;
+        if (!methodName.EndsWith("Async"))
+            return;
+
+        // Get the containing class
+        var classDeclaration = methodDeclaration.FirstAncestorOrSelf<ClassDeclarationSyntax>();
+        if (classDeclaration == null)
+            return;
+
+        // Check if class name ends with "Controller"
+        var className = classDeclaration.Identifier.Text;
+        if (className.EndsWith("Controller"))
+            return;
+
+        // Check if method has a CancellationToken parameter
+        var hasCancellationToken = false;
+        var semanticModel = context.SemanticModel;
+
+        foreach (var parameter in methodDeclaration.ParameterList.Parameters) {
+            if (parameter.Type == null)
+                continue;
+            var parameterType = semanticModel.GetTypeInfo(parameter.Type).Type;
+            if (parameterType != null && parameterType.ToString() == "System.Threading.CancellationToken") {
+                hasCancellationToken = true;
+                break;
+            }
+        }
+
+        if (!hasCancellationToken) {
+            var diagnostic = Diagnostic.Create(
+                AsyncMethodsMustHaveCancellationToken,
+                methodDeclaration.Identifier.GetLocation(),
+                methodName);
+
+            context.ReportDiagnostic(diagnostic);
+        }
+    }
+}

--- a/src/Analyzers/Helpers/DiagnosticIds.cs
+++ b/src/Analyzers/Helpers/DiagnosticIds.cs
@@ -4,4 +4,5 @@ public static class DiagnosticIds
 {
     public const string NO_IMPLICIT_IQUERYABLE_CASTS = "SHANE001";
     public const string NO_SYNCHRONOUS_IQUERYABLE_CALLS = "SHANE002";
+    public const string ASYNC_METHODS_MUST_HAVE_CANCELLATION_TOKEN = "SHANE003";
 }

--- a/src/Tests/AsyncMethodsMustHaveCancellationTokenAnalyzerTests.cs
+++ b/src/Tests/AsyncMethodsMustHaveCancellationTokenAnalyzerTests.cs
@@ -1,0 +1,136 @@
+using Xunit;
+using VerifyCS = Tests.CSharpAnalyzerVerifier<Shane32.Analyzers.AsyncMethodsMustHaveCancellationTokenAnalyzer>;
+
+namespace Tests;
+
+public class AsyncMethodsMustHaveCancellationTokenAnalyzerTests
+{
+    [Fact]
+    public async Task AsyncMethodWithoutCancellationToken_Diagnostic()
+    {
+        const string source =
+            """
+            using System.Threading.Tasks;
+
+            public class TestService
+            {
+                public async Task GetDataAsync()
+                {
+                    await Task.Delay(100);
+                    return;
+                }
+            }
+            """
+        ;
+
+        await VerifyCS.VerifyAnalyzerAsync(source,
+            VerifyCS.Diagnostic().WithSpan(5, 23, 5, 35).WithArguments("GetDataAsync"));
+    }
+
+    [Fact]
+    public async Task AsyncMethodWithCancellationToken_NoDiagnostic()
+    {
+        const string source =
+            """
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            public class TestService
+            {
+                public async Task GetDataAsync(CancellationToken cancellationToken)
+                {
+                    await Task.Delay(100, cancellationToken);
+                    return;
+                }
+            }
+            """
+        ;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task AsyncMethodInControllerWithoutCancellationToken_NoDiagnostic()
+    {
+        const string source =
+            """
+            using System.Threading.Tasks;
+
+            public class TestController
+            {
+                public async Task GetDataAsync()
+                {
+                    await Task.Delay(100);
+                    return;
+                }
+            }
+            """
+        ;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task NonAsyncMethodWithoutCancellationToken_NoDiagnostic()
+    {
+        const string source =
+            """
+            using System.Threading.Tasks;
+
+            public class TestService
+            {
+                public Task GetData()
+                {
+                    return Task.Delay(100);
+                }
+            }
+            """
+        ;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task AsyncMethodWithCancellationTokenAsLastParameter_NoDiagnostic()
+    {
+        const string source =
+            """
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            public class TestService
+            {
+                public async Task GetDataAsync(string id, int count, CancellationToken cancellationToken)
+                {
+                    await Task.Delay(100, cancellationToken);
+                    return;
+                }
+            }
+            """
+        ;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task AsyncMethodWithOptionalCancellationToken_NoDiagnostic()
+    {
+        const string source =
+            """
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            public class TestService
+            {
+                public async Task GetDataAsync(CancellationToken cancellationToken = default)
+                {
+                    await Task.Delay(100, cancellationToken);
+                    return;
+                }
+            }
+            """
+        ;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an analyzer that checks asynchronous methods for the inclusion of a cancellation token, promoting best practices in asynchronous operations while exempting controller scenarios.
  
- **Documentation**
  - Updated the release notes and documentation to detail the new analyzer rule and provide guidance for resolving any warnings.
  
- **Tests**
  - Added comprehensive tests to verify the analyzer’s behavior across various asynchronous and non-asynchronous method scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->