### PR TITLE
Don't warn on overridden members, interface members, or methods with HttpContext

### DIFF
--- a/src/Analyzers/AsyncMethodsMustHaveCancellationTokenAnalyzer.cs
+++ b/src/Analyzers/AsyncMethodsMustHaveCancellationTokenAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -54,19 +55,34 @@ public class AsyncMethodsMustHaveCancellationTokenAnalyzer : DiagnosticAnalyzer
                 return;
         }
 
-        // Check if method has a CancellationToken parameter
-        var hasCancellationToken = false;
         var semanticModel = context.SemanticModel;
+
+        // Skip if method overrides a base member or implements an interface member
+        if (IsOverrideOrInterfaceImplementation(methodDeclaration, semanticModel))
+            return;
+
+        // Check if method has a CancellationToken parameter or HttpContext parameter
+        var hasCancellationToken = false;
+        var hasHttpContext = false;
 
         foreach (var parameter in methodDeclaration.ParameterList.Parameters) {
             if (parameter.Type == null)
                 continue;
             var parameterType = semanticModel.GetTypeInfo(parameter.Type).Type;
-            if (parameterType != null && parameterType.ToString() == "System.Threading.CancellationToken") {
-                hasCancellationToken = true;
-                break;
+            if (parameterType != null) {
+                var typeString = parameterType.ToString();
+                if (typeString == "System.Threading.CancellationToken") {
+                    hasCancellationToken = true;
+                }
+                else if (typeString == "Microsoft.AspNetCore.Http.HttpContext") {
+                    hasHttpContext = true;
+                }
             }
         }
+
+        // Skip if method has HttpContext parameter (common in ASP.NET Core minimal APIs)
+        if (hasHttpContext)
+            return;
 
         if (!hasCancellationToken) {
             var diagnostic = Diagnostic.Create(
@@ -76,5 +92,36 @@ public class AsyncMethodsMustHaveCancellationTokenAnalyzer : DiagnosticAnalyzer
 
             context.ReportDiagnostic(diagnostic);
         }
+    }
+
+    private static bool IsOverrideOrInterfaceImplementation(MethodDeclarationSyntax methodDeclaration, SemanticModel semanticModel)
+    {
+        // Check if method has override modifier
+        if (methodDeclaration.Modifiers.Any(SyntaxKind.OverrideKeyword))
+            return true;
+
+        // Get the method symbol to check if it implements an interface
+        var methodSymbol = semanticModel.GetDeclaredSymbol(methodDeclaration);
+        if (methodSymbol == null)
+            return false;
+
+        // Check if the method implements an interface member
+        var containingType = methodSymbol.ContainingType;
+        if (containingType == null)
+            return false;
+
+        // Check all interfaces implemented by the containing type
+        foreach (var interfaceType in containingType.AllInterfaces)
+        {
+            foreach (var interfaceMember in interfaceType.GetMembers().OfType<IMethodSymbol>())
+            {
+                // Check if this method implements the interface method
+                var implementation = containingType.FindImplementationForInterfaceMember(interfaceMember);
+                if (SymbolEqualityComparer.Default.Equals(implementation, methodSymbol))
+                    return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Tests/AsyncMethodsMustHaveCancellationTokenAnalyzerTests.cs
+++ b/src/Tests/AsyncMethodsMustHaveCancellationTokenAnalyzerTests.cs
@@ -151,4 +151,186 @@ public class AsyncMethodsMustHaveCancellationTokenAnalyzerTests
         await VerifyCS.VerifyAnalyzerAsync(source,
             VerifyCS.Diagnostic().WithSpan(5, 10, 5, 22).WithArguments("GetDataAsync"));
     }
+
+    [Fact]
+    public async Task AsyncOverrideMethodWithoutCancellationToken_NoDiagnostic()
+    {
+        const string source =
+            """
+            using System.Threading.Tasks;
+
+            public abstract class BaseService
+            {
+                public abstract Task ProcessAsync();
+            }
+
+            public class TestService : BaseService
+            {
+                public override async Task ProcessAsync()
+                {
+                    await Task.Delay(100);
+                }
+            }
+            """
+        ;
+
+        // The abstract method should trigger a diagnostic, but the override should not
+        await VerifyCS.VerifyAnalyzerAsync(source,
+            VerifyCS.Diagnostic().WithSpan(5, 26, 5, 38).WithArguments("ProcessAsync"));
+    }
+
+    [Fact]
+    public async Task AsyncInterfaceImplementationWithoutCancellationToken_NoDiagnostic()
+    {
+        const string source =
+            """
+            using System.Threading.Tasks;
+
+            public interface ITestService
+            {
+                Task GetDataAsync();
+            }
+
+            public class TestService : ITestService
+            {
+                public async Task GetDataAsync()
+                {
+                    await Task.Delay(100);
+                }
+            }
+            """
+        ;
+
+        // The interface method should trigger a diagnostic, but the implementation should not
+        await VerifyCS.VerifyAnalyzerAsync(source,
+            VerifyCS.Diagnostic().WithSpan(5, 10, 5, 22).WithArguments("GetDataAsync"));
+    }
+
+    [Fact]
+    public async Task AsyncExplicitInterfaceImplementationWithoutCancellationToken_NoDiagnostic()
+    {
+        const string source =
+            """
+            using System.Threading.Tasks;
+
+            public interface ITestService
+            {
+                Task ProcessDataAsync();
+            }
+
+            public class TestService : ITestService
+            {
+                async Task ITestService.ProcessDataAsync()
+                {
+                    await Task.Delay(100);
+                }
+            }
+            """
+        ;
+
+        // The interface method should trigger a diagnostic, but the explicit implementation should not
+        await VerifyCS.VerifyAnalyzerAsync(source,
+            VerifyCS.Diagnostic().WithSpan(5, 10, 5, 26).WithArguments("ProcessDataAsync"));
+    }
+
+    [Fact]
+    public async Task AsyncMethodInDerivedClassNotOverridingWithoutCancellationToken_Diagnostic()
+    {
+        const string source =
+            """
+            using System.Threading.Tasks;
+
+            public abstract class BaseService
+            {
+                public abstract Task ProcessAsync();
+            }
+
+            public class TestService : BaseService
+            {
+                public override async Task ProcessAsync()
+                {
+                    await Task.Delay(100);
+                }
+
+                public async Task GetDataAsync()
+                {
+                    await Task.Delay(100);
+                }
+            }
+            """
+        ;
+
+        // The abstract method and the non-override method should both trigger diagnostics
+        await VerifyCS.VerifyAnalyzerAsync(source,
+            VerifyCS.Diagnostic().WithSpan(5, 26, 5, 38).WithArguments("ProcessAsync"),
+            VerifyCS.Diagnostic().WithSpan(15, 23, 15, 35).WithArguments("GetDataAsync"));
+    }
+
+    [Fact]
+    public async Task AsyncMethodImplementingInterfaceWithMultipleInterfaces_NoDiagnostic()
+    {
+        const string source =
+            """
+            using System.Threading.Tasks;
+
+            public interface IFirstService
+            {
+                Task GetDataAsync();
+            }
+
+            public interface ISecondService
+            {
+                Task ProcessAsync();
+            }
+
+            public class TestService : IFirstService, ISecondService
+            {
+                public async Task GetDataAsync()
+                {
+                    await Task.Delay(100);
+                }
+
+                public async Task ProcessAsync()
+                {
+                    await Task.Delay(100);
+                }
+            }
+            """
+        ;
+
+        // The interface methods should trigger diagnostics, but the implementations should not
+        await VerifyCS.VerifyAnalyzerAsync(source,
+            VerifyCS.Diagnostic().WithSpan(5, 10, 5, 22).WithArguments("GetDataAsync"),
+            VerifyCS.Diagnostic().WithSpan(10, 10, 10, 22).WithArguments("ProcessAsync"));
+    }
+
+    [Fact]
+    public async Task AsyncMethodWithHttpContextParameterWithoutCancellationToken_NoDiagnostic()
+    {
+        const string source =
+            """
+            using System.Threading.Tasks;
+
+            namespace Microsoft.AspNetCore.Http
+            {
+                public class HttpContext { }
+            }
+
+            public class TestService
+            {
+                public async Task ProcessRequestAsync(Microsoft.AspNetCore.Http.HttpContext context)
+                {
+                    await Task.Delay(100);
+                }
+
+                public async Task ProcessRequestWithDataAsync(Microsoft.AspNetCore.Http.HttpContext context, string data)
+                {
+                    await Task.Delay(100);
+                }
+            }
+            """
+        ;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analyzer to avoid reporting diagnostics for async methods that override base class members, implement interface members, or accept an HttpContext parameter.
* **Tests**
  * Added comprehensive test cases to ensure correct diagnostic reporting, especially for overrides, interface implementations, and methods with HttpContext parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->